### PR TITLE
Include missing declaration and align element name

### DIFF
--- a/content/articles/2019-06-04-code-quality-and-web-performance-the-myths-the-dos-and-the-donts.md
+++ b/content/articles/2019-06-04-code-quality-and-web-performance-the-myths-the-dos-and-the-donts.md
@@ -27,7 +27,8 @@ const mainWrapper = document.querySelector('.wrapper');
 
 
 if (mainWrapper) {
-    const element = document.querySelector('.inner-box');
+    const enabledInteractionClass = 'enabled-box';
+    const element = document.querySelector('.inner-elm');
 
     element.classList.add(enabledInteractionClass);
     mainWrapper.classList.remove(enabledInteractionClass);


### PR DESCRIPTION
The comparisons between the before and after weren't as obvious, even with the paragraph that followed, due to a missing declaration and element names not aligning.

Also of note, the before removes a class from the mainWrapper while the "optimized" code does not, so it's not even a direct replacement (which can be a side-effect of poor refactoring optimizations in reality as well).